### PR TITLE
remove unnecessary checks

### DIFF
--- a/lib_toggl/__init__.py
+++ b/lib_toggl/__init__.py
@@ -2,5 +2,5 @@
 """
 
 # TODO build pre-commit hook or CI/CD step to ensure this tracks pyproject.toml
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 __all__ = ["client", "account", "time_entries"]

--- a/lib_toggl/client.py
+++ b/lib_toggl/client.py
@@ -524,20 +524,11 @@ class Toggl:
         Args:
             te (TimeEntry): The TimeEntry object to be processed.
 
-        Raises:
-            ValueError: If the provided TimeEntry object is not valid.
-            ValueError: If the operation on the TimeEntry object fails.
-
         Returns:
             TimeEntry | None: The processed TimeEntry object if successful, None otherwise.
         """
         validate_workspace_id(te.workspace_id)
         validate_time_entry_id(te.id)
-        # Don't bother stopping a TE that doesn't have required info or has already been stopped
-        if te.stop is not None:
-            raise ValueError("Time Entry is already stopped")
-        if te.start is None:
-            raise ValueError("Time Entry has no start time")
 
         log.info(
             "stop_time_entry is alive...",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lib-toggl"
-version = "0.1.6"
+version = "0.1.7"
 description = "Asynchronous Python library for the Toggl API."
 authors = ["Karl Quinsalnd <karl@karlquinsland.com>"]
 readme = "README.md"


### PR DESCRIPTION
They actively break a particular / valid ha-toggl-track workflow (see: https://github.com/kquinsland/ha-toggl-track/issues/15)