### PR TITLE
Fix: existing unit tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "python.analysis.typeCheckingMode": "basic"
+  "python.analysis.typeCheckingMode": "basic",
+  "python.testing.pytestArgs": ["tests"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,14 +11,14 @@ async def test_client_init_no_api_key():
     """Tests that client requires an API key"""
     with pytest.raises(TypeError):
         # pylint: disable=no-value-for-parameter
-        _ = client.Toggl()  # pyright: ignore reportCallIssue
+        _ = Toggl()  # pyright: ignore reportCallIssue
 
 
 @pytest.mark.asyncio
 async def test_client_init_with_api_key():
     """Tests that client requires an API key"""
     _key = "fake_api_key"
-    x = client.Toggl(_key)
+    x = Toggl(_key)
     assert x.api_key == _key
 
 

--- a/tests/test_time_entry.py
+++ b/tests/test_time_entry.py
@@ -166,8 +166,8 @@ def test_time_entry_instantiation_with_valid_data():
     assert valid_no_tags_ids.description == "Test Description"
 
     # pylint: disable=use-implicit-booleaness-not-comparison
-    assert valid_no_tags.tags == []
+    assert valid_no_tags.tags is None
     assert valid_no_tags_ids.tags == []
 
     assert valid_no_tags.tag_ids == []
-    assert valid_no_tags_ids.tag_ids == []
+    assert valid_no_tags_ids.tag_ids is None


### PR DESCRIPTION
Hey there, thanks for your work on this library! I'm checking it out for integrating in a (non-HA) project as it seems to be the most up-to-date Toggl API implementation that I could find... so thanks again!

This PR is just a few small fixes to the existing Pytests, so I could get them to run and pass in my local VS Code.

I hope you're OK with suggestions and PRs? I can file an issue first if you'd like.