### PR TITLE
Feat: get version from package at runtime

### DIFF
--- a/.vscode/lib-toggl.code-workspace
+++ b/.vscode/lib-toggl.code-workspace
@@ -47,6 +47,7 @@
       "stdlib",
       "structlog",
       "togglpy",
+      "toggl",
       "virtualenv",
       "virtualenvs",
       "webassets"

--- a/lib_toggl/__init__.py
+++ b/lib_toggl/__init__.py
@@ -1,6 +1,12 @@
 """lib-toggl
 """
 
-# TODO build pre-commit hook or CI/CD step to ensure this tracks pyproject.toml
-__version__ = "0.1.8"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("lib-toggl")
+except PackageNotFoundError:
+    __version__ = None
+
+
 __all__ = ["client", "account", "time_entries"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,21 @@
+import importlib.metadata
+import re
+
+
+def test_version_found():
+    from lib_toggl import __version__
+
+    assert __version__ is not None
+    assert re.match(r"\d+\.\d+\.\d+", __version__)
+
+
+def test_version_not_found(monkeypatch):
+    # patching importlib.metadata.version() to raise an exception
+    def _version_raise(distribution_name):
+        raise importlib.metadata.PackageNotFoundError()
+
+    monkeypatch.setattr(importlib.metadata, "version", _version_raise)
+
+    from lib_toggl import __version__
+
+    assert __version__ is None


### PR DESCRIPTION
Closes #13 

Within Python code, use the `version()` helper from [`importlib.metadata`](https://docs.python.org/3/library/importlib.metadata.html) to get the version of the installed `lib-toggl` pacakge.