### PR TITLE
Make intercom_hash optional

### DIFF
--- a/lib_toggl/account.py
+++ b/lib_toggl/account.py
@@ -41,4 +41,4 @@ class Account(BaseModel):  # pyright: ignore[reportGeneralTypeIssues]
     has_password: bool
     at: datetime
     # Analytics?
-    intercom_hash: SecretStr
+    intercom_hash: Optional[SecretStr] = None


### PR DESCRIPTION
Might fix the intercom_hash (see below) related problem. Not 100% sure it's the correct fix but after this change I can run `scripts/poc.py` again 

```
pydantic.v1.error_wrappers.ValidationError: 1 validation error for Account
intercom_hash
  field required (type=value_error.missing)
```

See https://github.com/kquinsland/ha-toggl-track/issues/53